### PR TITLE
Only install typing on python < 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    install_requires=["pytz", "typing"],
+    install_requires=["pytz", "typing;python_version<\"3.5\""],
     extras_require={"graph": ["graphviz >= 0.8.1"], "redis": ["redis >= 2.10"]},
 )


### PR DESCRIPTION
This makes sure that when installing tuco with newer python versions and using poetry it won't break.
```
Command ['/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/bin/pip', 'install', '--no-deps', '/home/hermes/.cache/pypoetry/artifacts/da/4c/55/bb39bdc3879cb509b92ddbd67d1a5b2764067b53ba3b2dd1c1f2110ca9/tuco-0.3.0.tar.gz'] errored with the following return code 1, and output: 
  Processing /home/hermes/.cache/pypoetry/artifacts/da/4c/55/bb39bdc3879cb509b92ddbd67d1a5b2764067b53ba3b2dd1c1f2110ca9/tuco-0.3.0.tar.gz
    Installing build dependencies: started
    Installing build dependencies: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: /home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/bin/python /home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-26o7ke8a/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel
         cwd: None
    Complete output (44 lines):
    Traceback (most recent call last):
      File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
        "__main__", mod_spec)
      File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/__main__.py", line 26, in <module>
        sys.exit(_main())
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_internal/cli/main.py", line 73, in main
        command = create_command(cmd_name, isolated=("--isolated" in cmd_args))
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_internal/commands/__init__.py", line 104, in create_command
        module = importlib.import_module(module_path)
      File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
      File "<frozen importlib._bootstrap>", line 983, in _find_and_load
      File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 728, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 24, in <module>
        from pip._internal.cli.req_command import RequirementCommand, with_cleanup
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_internal/cli/req_command.py", line 16, in <module>
        from pip._internal.index.package_finder import PackageFinder
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_internal/index/package_finder.py", line 21, in <module>
        from pip._internal.index.collector import parse_links
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_internal/index/collector.py", line 14, in <module>
        from pip._vendor import html5lib, requests
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_vendor/requests/__init__.py", line 114, in <module>
        from . import utils
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_vendor/requests/utils.py", line 25, in <module>
        from . import certs
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_vendor/requests/certs.py", line 15, in <module>
        from pip._vendor.certifi import where
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_vendor/certifi/__init__.py", line 1, in <module>
        from .core import contents, where
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/pip/_vendor/certifi/core.py", line 12, in <module>
        from importlib.resources import read_text
      File "/usr/local/lib/python3.7/importlib/resources.py", line 11, in <module>
        from typing import Iterable, Iterator, Optional, Set, Union   # noqa: F401
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/typing.py", line 1359, in <module>
        class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
      File "/home/hermes/.cache/pypoetry/virtualenvs/hermes-ycUgctgk-py3.7/lib/python3.7/site-packages/typing.py", line 1007, in __new__
        self._abc_registry = extra._abc_registry
    AttributeError: type object 'Callable' has no attribute '_abc_registry'`
```